### PR TITLE
update for recent GHC

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,3 +1,7 @@
+### Version 0.0.0.2 (2019-05-15)
+
+  * Cabal update: fix compile for recent GHC versions.
+
 ### Version 0.0.0.1 (2016-10-30)
 
   * Documentation fixes: significant portions of the haddocks failed

--- a/Data/Configurator/Config/Implementation.hs
+++ b/Data/Configurator/Config/Implementation.hs
@@ -21,7 +21,6 @@ import           Data.Typeable
 import           Data.CritBit.Map.Lazy (CritBit)
 import qualified Data.CritBit.Map.Lazy as CB
 import qualified Data.List.Ordered as OL
-import           Data.Monoid
 import           Data.Function (on)
 import           Data.Text(Text)
 import qualified Data.Text as T

--- a/Data/Configurator/FromValue/Implementation.hs
+++ b/Data/Configurator/FromValue/Implementation.hs
@@ -31,7 +31,6 @@ import           Data.Configurator.Types.Internal
                    )
 import           Data.Fixed (Fixed, HasResolution)
 import           Data.Int(Int8, Int16, Int32, Int64)
-import           Data.Monoid
 import           Data.Ratio ( Ratio, (%) )
 import           Data.Scientific
                    ( Scientific,  coefficient, base10Exponent, normalize

--- a/Data/Configurator/Parser/Implementation.hs
+++ b/Data/Configurator/Parser/Implementation.hs
@@ -17,7 +17,6 @@ import qualified Data.Configurator.Config as C
 import           Data.Configurator.Config.Implementation (ConfigPlan(..))
 import           Data.Configurator.Types (ConfigError)
 import           Data.DList (DList)
-import           Data.Monoid
 import           Data.Text (Text)
 import           Data.Typeable (Typeable)
 

--- a/Data/Configurator/Parser/Implementation.hs
+++ b/Data/Configurator/Parser/Implementation.hs
@@ -149,17 +149,19 @@ instance ConfigParser ConfigParserA where
 --   of reliable dependency tracking in later versions of configurator-ng.
 newtype ConfigTransform = ConfigTransform (ConfigPlan ())
 
--- | 'mempty' is the identity 'ConfigTransform',  'mappend' is the composition
+-- | 'mempty' is the identity 'ConfigTransform',  <> is the composition
 --   of two 'ConfigTransform's.
-instance Monoid ConfigTransform where
-   mempty = ConfigTransform (ConfigPlan ())
-   (ConfigTransform x) `mappend` (ConfigTransform y) = (ConfigTransform (go x))
+instance Semigroup ConfigTransform where
+   (ConfigTransform x) <> (ConfigTransform y) = (ConfigTransform (go x))
      where
        go (ConfigPlan _)      = y
        go (Union a b)         = Union (go a) (go b)
        go (Superconfig pre a) = Superconfig pre (go a)
        go (Subconfig pre a)   = Subconfig pre (go a)
        go Empty               = Empty
+
+instance Monoid ConfigTransform where
+   mempty = ConfigTransform (ConfigPlan ())
 
 -- | Conceptually,  @'union' f g = \\config -> union\' (f config) (g config)@,
 -- where @union\'@ is the left-biased union of two 'Config's.

--- a/configurator-ng.cabal
+++ b/configurator-ng.cabal
@@ -1,5 +1,5 @@
 name:            configurator-ng
-version:         0.0.0.1
+version:         0.0.0.2
 license:         BSD3
 license-file:    LICENSE
 category:        Configuration, Data

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,7 +1,7 @@
-resolver: lts-5.17
+resolver: lts-13.21
 
 packages:
 - '.'
 
 extra-deps:
-- critbit-0.2.0.0
+- critbit-0.2.1.0

--- a/tests/Test.hs
+++ b/tests/Test.hs
@@ -13,7 +13,6 @@ import           Data.Configurator
 import           Data.Configurator.Parser
 import           Data.Configurator.Types
 import           Data.Function (on)
-import           Data.Functor
 import           Data.Int
 import           Data.List (sortBy)
 import           Data.Maybe


### PR DESCRIPTION
Once critbit PR https://github.com/bos/critbit/pull/93 makes it to hackage, this change should allow building the package with current GHC releases. In particular, it might help people trying to build postgrest.